### PR TITLE
ACME 30490/ACME 30491/change team references

### DIFF
--- a/catalog-info.repo.yaml
+++ b/catalog-info.repo.yaml
@@ -8,4 +8,4 @@ metadata:
 spec:
   type: github-repository
   lifecycle: stable
-  owner: cloud-security-team
+  owner: cloud-enrichment


### PR DESCRIPTION
This pull request includes a small change to the `catalog-info.repo.yaml` file. The change updates the owner of the repository from the `cloud-security-team` to `cloud-enrichment`.

* [`catalog-info.repo.yaml`](diffhunk://#diff-41512ade51506bb22fa3fb7ee61b9ae1e6f7a9abbef87d010ee35ff0e8d082e7L11-R11): Changed the `owner` field from `cloud-security-team` to `cloud-enrichment`.
